### PR TITLE
Attempt at generating addresses natively

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "type": "library",
     "require": {
         "ext-bcmath": "*",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3",
+        "ionux/phactor": "1.0.8",
+        "kornrunner/keccak": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f92bdcb6e8579fbf465c979fbc18152",
+    "content-hash": "6c65065dbcd3c145a980a2d3ae60fe4a",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -188,6 +188,145 @@
             "time": "2017-03-20T17:10:46+00:00"
         },
         {
+            "name": "ionux/phactor",
+            "version": "v1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ionux/phactor.git",
+                "reference": "271373b65cffe75a8c28f7f8c392fe460251f4f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ionux/phactor/zipball/271373b65cffe75a8c28f7f8c392fe460251f4f7",
+                "reference": "271373b65cffe75a8c28f7f8c392fe460251f4f7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-openssl": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.9"
+            },
+            "suggest": {
+                "ext-gmp": "Highest performing math library and preferred for this library's Elliptic Curve calculations."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phactor\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rich Morgan",
+                    "email": "rich@richmorgan.me",
+                    "role": "Creator and Lead Developer"
+                }
+            ],
+            "description": "Phactor is a high-performance PHP implementation of the elliptic curve math functions required to generate & verify private/public (asymmetric) EC keypairs and ECDSA signatures based on secp256k1 curve parameters. This library also includes a class to generate Service Identification Numbers (SINs) based on the published Identity Protocol v1 spec.",
+            "homepage": "https://github.com/ionux/phactor",
+            "keywords": [
+                "Algorithm",
+                "BIP",
+                "ECDSA",
+                "SIN",
+                "arbitrary",
+                "asymmetric",
+                "base",
+                "base58",
+                "bcmath",
+                "binary",
+                "bitcoin",
+                "calculator",
+                "coprime",
+                "crypto",
+                "cryptography",
+                "curve",
+                "digital",
+                "dsa",
+                "ec",
+                "elliptic",
+                "encryption",
+                "generate",
+                "gmp",
+                "hex",
+                "identification",
+                "identity",
+                "integer",
+                "key",
+                "keygen",
+                "keypair",
+                "keys",
+                "library",
+                "math",
+                "number",
+                "performance",
+                "phactor",
+                "precision",
+                "prime",
+                "private",
+                "protocol",
+                "public",
+                "secp256k1",
+                "service",
+                "signature",
+                "verify"
+            ],
+            "time": "2018-04-27T16:49:28+00:00"
+        },
+        {
+            "name": "kornrunner/keccak",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kornrunner/php-keccak.git",
+                "reference": "ad761f528f4d1e3ce378b8a0841e5f82c9973535"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kornrunner/php-keccak/zipball/ad761f528f4d1e3ce378b8a0841e5f82c9973535",
+                "reference": "ad761f528f4d1e3ce378b8a0841e5f82c9973535",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0",
+                "symfony/polyfill-mbstring": "^1.8"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "~7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "kornrunner\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Boris Momcilovic",
+                    "homepage": "https://github.com/kornrunner/php-keccak"
+                }
+            ],
+            "description": "Pure PHP implementation of Keccak",
+            "keywords": [
+                "keccak",
+                "sha-3",
+                "sha3-256"
+            ],
+            "time": "2018-07-30T22:16:23+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -236,6 +375,65 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
         }
     ],
     "packages-dev": [
@@ -292,6 +490,188 @@
                 "instantiate"
             ],
             "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "fgrosse/phpasn1",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fgrosse/PHPASN1.git",
+                "reference": "0e27e71e3d0a8d5c3f1471d727fd9574d920f33c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fgrosse/PHPASN1/zipball/0e27e71e3d0a8d5c3f1471d727fd9574d920f33c",
+                "reference": "0e27e71e3d0a8d5c3f1471d727fd9574d920f33c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gmp": "*",
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.3",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "suggest": {
+                "php-curl": "For loading OID information from the web if they have not bee defined statically"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "FG\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Friedrich Große",
+                    "email": "friedrich.grosse@gmail.com",
+                    "homepage": "https://github.com/FGrosse",
+                    "role": "Author"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/FGrosse/PHPASN1/contributors"
+                }
+            ],
+            "description": "A PHP Framework that allows you to encode and decode arbitrary ASN.1 structures using the ITU-T X.690 Encoding Rules.",
+            "homepage": "https://github.com/FGrosse/PHPASN1",
+            "keywords": [
+                "DER",
+                "asn.1",
+                "asn1",
+                "ber",
+                "binary",
+                "decoding",
+                "encoding",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "time": "2017-12-17T10:21:51+00:00"
+        },
+        {
+            "name": "kornrunner/secp256k1",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kornrunner/php-secp256k1.git",
+                "reference": "24cc0bbac3405040e2f160f58e6fc2b6d9fe7a7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kornrunner/php-secp256k1/zipball/24cc0bbac3405040e2f160f58e6fc2b6d9fe7a7c",
+                "reference": "24cc0bbac3405040e2f160f58e6fc2b6d9fe7a7c",
+                "shasum": ""
+            },
+            "require": {
+                "mdanter/ecc": "~0.5",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "~7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "kornrunner\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Boris Momčilović",
+                    "email": "boris.momcilovic@gmail.com"
+                }
+            ],
+            "description": "Pure PHP secp256k1",
+            "time": "2018-07-25T13:32:20+00:00"
+        },
+        {
+            "name": "mdanter/ecc",
+            "version": "v0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpecc/phpecc.git",
+                "reference": "ed5c6d496f5310de1b7071b8375fafa3559a1344"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpecc/phpecc/zipball/ed5c6d496f5310de1b7071b8375fafa3559a1344",
+                "reference": "ed5c6d496f5310de1b7071b8375fafa3559a1344",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gmp": "*",
+                "fgrosse/phpasn1": "v2.0.x",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0",
+                "squizlabs/php_codesniffer": "~2",
+                "symfony/yaml": "~2.6|~3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Mdanter\\Ecc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matyas Danter",
+                    "homepage": "http://matejdanter.com/",
+                    "role": "Author"
+                },
+                {
+                    "name": "Thibaud Fabre",
+                    "email": "thibaud@aztech.io",
+                    "homepage": "http://aztech.io",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Thomas Kerin",
+                    "email": "afk11@users.noreply.github.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "PHP Elliptic Curve Cryptography library",
+            "homepage": "https://github.com/phpecc/phpecc",
+            "keywords": [
+                "Diffie",
+                "ECDSA",
+                "Hellman",
+                "curve",
+                "ecdh",
+                "elliptic",
+                "nistp192",
+                "nistp224",
+                "nistp256",
+                "nistp384",
+                "nistp521",
+                "phpecc",
+                "secp256k1",
+                "secp256r1"
+            ],
+            "time": "2017-10-09T16:05:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1923,65 +2303,6 @@
                 "ctype",
                 "polyfill",
                 "portable"
-            ],
-            "time": "2018-08-06T14:22:27+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
             ],
             "time": "2018-08-06T14:22:27+00:00"
         },

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -6,6 +6,7 @@ use kornrunner\Keccak;
 use mattvb91\TronTrx\Exceptions\TransactionException;
 use mattvb91\TronTrx\Exceptions\TronErrorException;
 use mattvb91\TronTrx\Interfaces\WalletInterface;
+use mattvb91\TronTrx\Support\Base58Check;
 use mattvb91\TronTrx\Traits\TronAwareTrait;
 use Phactor\Key;
 
@@ -37,22 +38,9 @@ class Wallet implements WalletInterface
                 $privateKey = "0$privateKey";
             }
 
-            $x = $this->toHex($info["public_key_x"]);
-            $y = $this->toHex($info["public_key_y"]);
-
-            while (strlen($x) < 64) {
-                $x = "0$x";
-            }
-
-            while (strlen($y) < 64) {
-                $y = "0$y";
-            }
-
-            $publicKeyHex = "04$x$y";
-            $hash = Keccak::hash($publicKeyHex, 256);
-
-            $addressHex = Address::ADDRESS_PREFIX . substr($hash, 24, strlen($hash));
-            $address = $this->hexString2Address($addressHex);
+            $hash = Keccak::hash($info['public_key'], 256);
+            $addressHex = substr($hash, 24, strlen($hash));
+            $address = Base58Check::encode($addressHex, Address::ADDRESS_PREFIX_BYTE, false);
 
             $address = new Address($address, $privateKey, $this->toHex($address));
 


### PR DESCRIPTION
Attempt to generate addresses locally instead of getting a private key posted over network from the trongrid api.

Using the tron-web js lib as reference in (reverse engineering) it natively into PHP
https://github.com/tronprotocol/tron-web/blob/master/src/utils/accounts.js

For quick reading this is the PHP side: 
https://github.com/mattvb91/tron-trx-php/pull/2/files#diff-458c0e1e8777d0a37c9e00ea29a09bc4R27

This is the js side:
https://github.com/tronprotocol/tron-web/blob/master/src/utils/crypto.js#L191

Libs being used:
https://github.com/ionux/phactor for secp256k1 curve
https://github.com/kornrunner/php-keccak for keccak hash

## Currently working: 

- The generated address is valid when double checking against /wallet/validateaddress

## Current issue: 
- The private key generated is prepended with `0x`. Once that is removed it seems to be fine logging in with it on trongrid explorer (This is probably already an issue on its own).

The 0x is prepended here: 
https://github.com/ionux/phactor/blob/667064d3930e043fd78abed9a2324aee52466fa5/src/Math.php#L194

- The address shown on trongrid is not the address generated. (Probably has to do with the `0x` issue in the private key being the private key is actually not valid)

